### PR TITLE
【フロントサイド】プロフィール編集画面のビュー

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -16,4 +16,7 @@
 @import "articles/show";
 
 // errors
-@import "errors/error"
+@import "errors/error";
+
+// profiles
+@import "profiles/edit";

--- a/app/assets/stylesheets/profiles/edit.scss
+++ b/app/assets/stylesheets/profiles/edit.scss
@@ -1,0 +1,201 @@
+.p-settings {
+  color: #555;
+  .p-settings_container {
+    display: flex;
+    flex-flow: row wrap;
+    align-items: flex-start;
+    max-width: 110rem;
+    margin-right: auto;
+    margin-left: auto;
+    .p-settings_menu {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+      width: 28rem;
+      position: -webkit-sticky;
+      position: sticky;
+      top: 1em;
+      background-color: #fff;
+      border: 0.1rem solid transparent;
+      padding: 1.6rem;
+      font-size: 1.4rem;
+      .p-settings_menuItem:first-child {
+        border-top: none;
+        padding-top: 0;
+      }
+      .p-settings_menuItem {
+        width: 100%;
+        font-weight: 400;
+        padding: 0.8rem 0;
+        border-top: 0.1rem solid #e8e8e8;
+        color: #555;
+      }
+      .p-settings_menuItem-active {
+        font-weight: 700;
+      }
+    }
+    .p-settings_main {
+      flex-grow: 1;
+      width: 0;
+      min-width: 0;
+      margin-left: 1.6rem;
+      background-color: #fff;
+      border: 0.1rem solid transparent;
+      padding: 3.2rem;
+      .p-settings_titleSection {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        flex-wrap: wrap;
+        font-size: 2.4rem;
+        margin-bottom: 3.2rem;
+        .p-settings_userLogo {
+          display: flex;
+          overflow: hidden;
+          border-radius: .2em;
+          width: 3.2rem;
+          height: 3.2rem;
+          img {
+            width: 100%;
+            height: 100%;
+            border-radius: .2em;
+          }
+        }
+        .p-settings_userName:visited {
+          color: #555;
+        }
+        .p-settings_titleSeparator {
+          margin: 0 1.2rem;
+          font-size: 2.8rem;
+          color: #e8e8e8;
+        }
+        .p-settings_title {
+          font-weight: 700;
+        }
+      }
+      .simple_form{
+        .st-Form {
+          color: #555;
+          label{
+            font-size: 1.4rem;
+          }
+          .st-Form_label {
+            font-size: 1.4rem;
+            font-weight: 700;
+            color: currentColor;
+          }
+          .us-Form_twoColumn {
+            display: flex;
+            justify-content: space-between;
+            align-items: stretch;
+          }
+            .st-Form_text {
+              display: block;
+              width: 100%;
+              font-size: 1.6rem;
+              background-color: #fff;
+              border-radius: 0.3rem;
+              border: 0.1rem solid #ccc;
+              transition: border-color ease-in-out .15s,box-shadow ease-in-out .15s;
+              padding: 0.8rem 1.6rem;
+              cursor: text;
+              margin-top: .6em;
+            }
+          
+          .us-Form_twoColumn>* {
+            max-width: 49%;
+          }
+          .st-Form_group {
+            display: flex;
+            align-items: stretch;
+            justify-content: space-between;
+            border-radius: 0.3rem;
+            margin-top: .6em;
+            overflow: hidden;
+            .st-Form_groupBefore, .st-Form_groupAfter {
+              color: #555;
+              text-align: center;
+              background-color: #eee;
+              border: 0.1rem solid #ccc;
+              padding: 0 0.8rem;
+              display: flex;
+              align-items: center;
+              justify-content: center;
+            }
+            .st-Form_groupBefore {
+              border-right: 0;
+              font-size: 1.4rem;
+            }
+            .st-Form_groupText {
+              display: block;
+              flex: 1 1;
+              font-size: 1.6rem;
+              background-color: #fff;
+              border: 0.1rem solid #ccc;
+              transition: border-color ease-in-out .15s,box-shadow ease-in-out .15s;
+              padding: 0.8rem 1.6rem;
+              cursor: text;
+            }
+          }
+        }
+        .st-Form_help {
+          font-size: 1.4rem;
+          color: #999;
+          margin-top: .6em;
+        }
+        .st-Form:not(:first-child) {
+          margin-top: 2.5em;
+        }
+        .st-Form_submit {
+          display: block;
+          -webkit-appearance: button;
+          color: #fff;
+          background-color: #55c500;
+          border: none;
+          border-radius: .2em;
+          font-size: 1.4rem;
+          padding: 0.8rem 2.4rem;
+          margin: 2.4rem auto 0;
+          cursor: pointer;
+          text-decoration: none;
+
+        }
+      }
+    }
+    @media (max-width: 770px){
+      .px-1\@s {
+        padding-right: 0.8rem;
+        padding-left: 0.8rem;
+        padding-top: 0.8rem;
+      }
+      .p-settings_menu {
+        width: 100%;
+        position: static;
+      }
+      .p-settings_main {
+        width: 100%;
+        margin-top: 1.6rem;
+        margin-left: auto;
+      }
+      .p-settings_titleSection {
+        font-size: 1.8rem;
+        justify-content: start;
+      }
+      .p-settings_userLogo {
+        display: flex;
+        overflow: hidden;
+        border-radius: .2em;
+        width: 2rem;
+        height: 2rem;
+      }
+    }
+  }
+}
+
+.pt-4 {
+  padding-top: 3.2rem;
+}
+.px-2 {
+  padding-right: 1.6rem;
+  padding-left: 1.6rem;
+}

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
 class ProfilesController < ApplicationController
-  def show
-    @user = User.find_by(nickname: params[:user_name])
-  end
+  before_action :authenticate_user!, only: [:edit]
+
+  # def show
+  #   @user = User.find_by(nickname: params[:user_name])
+  # end
+
+  def edit; end
 end

--- a/app/views/profiles/edit.html.haml
+++ b/app/views/profiles/edit.html.haml
@@ -1,0 +1,57 @@
+= render "shared/header"
+.p-settings.px-2.pt-4{class: "px-1@s pt-1@s"}
+  .p-settings_container
+    .p-settings_menu
+      %a.p-settings_menuItem.p-settings_menuItem-active{href: "/settings/profile"} 公開用プロフィール
+      %a.p-settings_menuItem{href: ""} アカウント
+    .p-settings_main
+      .p-settings_titleSection
+        %a.p-settings_userLogo{href: ""}
+          %img{src: "https://pbs.twimg.com/profile_images/1174154846615662593/S8pmypM9_bigger.jpg"}
+        %a.p-settings_userName{href: ""}
+          ="@#{current_user.nickname} アカウント"
+        %span.p-settings_titleSeparator /
+        %span.p-settings_title 公開用プロフィール
+      %form#edit_user_549538.simple_form.edit_user
+        .st-Form
+          %label.string.optional.st-Form_label 名前
+          .us-Form_twoColumn
+            %input#user_first_name.st-Form_text{ placeholder: "名", type: "text"}/
+            %input#user_last_name.st-Form_text{ placeholder: "姓", type: "text"}/
+        .st-Form
+          %label.email.optional.st-Form_label 公開メールアドレス
+          %div
+            %label
+              %input{ type: "hidden", value: "0"}/
+              %input#user_public_email.st-Form_checkbox{ type: "checkbox" }/
+              メールアドレスを全体に公開する
+          .st-Form_help
+            誰もがあなたのメールアドレス(
+            %small
+              = current_user.email
+            )を見れる状態になります。
+            %a{href: "/settings/notifications"} メールアドレスを変更
+        .st-Form.team
+          %label.st-Form_label.position 所属チーム
+          %input#user_website_url.st-Form_text{type:"text"}        
+        .st-Form.position
+          %label.st-Form_label.position ポジション
+          %input#user_website_url.st-Form_text{type:"text"}
+        .st-Form.batting_throwing
+          %label.st-Form_label.batting_throwing 投打
+          %input#user_organization.st-Form_text{type:"text"}
+        .st-Form.text.optional.user_description
+          %label.st-Form_label.text.optional 自己紹介
+          %textarea#user_description.st-Form_text.text.optional
+        .st-Form
+          %label.string.optional.st-Form_label Twitter ID
+          .st-Form_group
+            .st-Form_groupBefore https://twitter.com/
+            %input#user_twitter_id.st-Form_groupText{ type:"text" }
+        .st-Form
+          %label.string.optional.st-Form_label Facebook ID
+          .st-Form_group
+            .st-Form_groupBefore https://www.facebook.com/
+            %input#user_facebook_id.st-Form_groupText{ type:"text" }
+        %input.st-Form_submit{type: "submit", value: "更新する"}/
+= render "shared/footer"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,4 +15,5 @@ Rails.application.routes.draw do
   root 'homes#index'
 
   get 'profile/:user_name', to: 'profiles#show'
+  get 'setting/profile', to: 'profiles#edit'
 end


### PR DESCRIPTION
# What
プロフィール編集のビューを作成しました。
主に以下のファイルを編集しました。
・profiles/edit.scss
・profiles/edit.html.haml 

※投打はサーバーサイド実装時にセレクトボックスに変更します。

# Why
プロフィール編集画面のビューを実装するため。
レビューの程よろしくお願いいたします。
<img width="1190" alt="スクリーンショット 2019-12-21 14 26 36" src="https://user-images.githubusercontent.com/56331466/71304514-4f2fe300-240b-11ea-82af-6ecddddf98d3.png">
<img width="613" alt="スクリーンショット 2019-12-21 16 00 50" src="https://user-images.githubusercontent.com/56331466/71304515-4f2fe300-240b-11ea-839f-dcc198c4b179.png">
