### PR TITLE
【フロントサイド】記事詳細画面のビュー修正

### DIFF
--- a/app/assets/stylesheets/articles/show.scss
+++ b/app/assets/stylesheets/articles/show.scss
@@ -5,8 +5,8 @@
     padding-bottom: 4rem;
     display: grid;
     display: -ms-grid;
-    grid-template-columns: 8rem calc(100% - 30rem - 8rem) 30rem;
-    -ms-grid-columns: 8rem calc(100% - 30rem - 8rem) 30rem;
+    grid-template-columns: 8rem calc(100% - 8rem);
+    -ms-grid-columns: 8rem calc(100% - 8rem);
     grid-template-rows: minmax(27rem,auto) 1fr;
     -ms-grid-rows: minmax(27rem,auto) 1fr;
     max-width: 128rem;
@@ -118,7 +118,7 @@
       grid-row: 1 / 3;
       -ms-grid-row: 1;
       -ms-grid-row-span: 3;
-      padding: 1.6rem;
+      padding: 1.6rem 15rem;
       .p-items_article {
         background-color: #fff;
         padding: 3.2rem;
@@ -149,7 +149,7 @@
                   margin-right: 0.8rem;
                 }
                 .it-Header_authorName {
-                  font-size: 1.8rem;
+                  font-size: 2rem;
                   color: inherit;
                 }
               }
@@ -410,73 +410,70 @@
           }
         }
         .ai-Container {
-          display: flex;
           width: 100%;
           padding-top: 4rem;
           border-top: 0.1rem solid #ddd;
           .ai-User {
-            display: flex;
             width: 100%;
             margin-right: 1.6rem;
             word-wrap: break-word;
             .ai-User_image {
-              display: flex;
               overflow: hidden;
               border-radius: .2em;
               width: 6rem;
               height: 6rem;
               margin-right: 1.6rem;
             }
-            .ai-User_body {
-              flex-grow: 1;
-              width: 0;
-              min-width: 0;
-              .ai-User_header {
-                display: flex;
-                flex-wrap: wrap;
-                align-items: center;
-                margin-bottom: 0.8rem;
-                .ai-User_name{
-                  color: inherit;
-                  font-size: 1.6rem;
-                  font-weight: 700;
-                  margin-right: 0.8rem;
-                }
-                .ai-User_urlname {
-                  font-size: 1.4rem;
-                  color: #999;
-                  margin-right: 0.8rem;
-                }
-                .ai-User_organization {
-                  width: 2.4rem;
-                  height: 2.4rem;
-                  border: 0.1rem solid #ddd;
-                  margin-right: 0.8rem;
+            .ai-User_header {
+              display: flex;
+              flex-wrap: wrap;
+              align-items: center;
+              margin-bottom: 0.8rem;
+              .ai-User_name{
+                color: inherit;
+                font-size: 1.8rem;
+                font-weight: 700;
+                margin-right: 0.8rem;
+                a{
+                  color:#14171A;
                 }
               }
-              .ai-User_description {
+              .ai-User_urlname {
+                font-size: 1.7rem;
+                margin-right: 0.8rem;
+                a{
+                  color: #657786;
+                }
+              }
+              .ai-User_organization {
+                width: 2.4rem;
+                height: 2.4rem;
+                border: 0.1rem solid #ddd;
+                margin-right: 0.8rem;
+              }
+            }
+            .ai-User_description {
+              font-size: 1.4rem;
+              color: #777;
+              margin-bottom: 0.4rem;
+            }
+            .ai-User_footer {
+              margin-top: 1.6rem;
+              display: flex;
+              align-items: center;
+              .it-UserFollowButton-follow {
+                background-color: #fff;
+              }
+              .it-UserFollowButton {
+                display: inline-block;
+                -webkit-appearance: button;
+                border: 0.1rem solid #ccc;
+                border-radius: .1em;
                 font-size: 1.4rem;
-                color: #777;
-                margin-bottom: 0.4rem;
-              }
-              .ai-User_footer {
-                margin-top: 1.6rem;
-                display: flex;
-                align-items: center;
-                .it-UserFollowButton-follow {
-                  background-color: #fff;
-                }
-                .it-UserFollowButton {
-                  display: inline-block;
-                  -webkit-appearance: button;
-                  border: 0.1rem solid #ccc;
-                  border-radius: .1em;
-                  font-size: 1.4rem;
-                  padding: 0.4rem 0;
-                  width: 12rem;
-                  text-align: center;
-                  cursor: pointer;
-                }
+                padding: 0.4rem 0;
+                width: 12rem;
+                text-align: center;
+                cursor: pointer;
               }
             }
           }
@@ -569,9 +566,6 @@
   }
 }
 @media (max-width: 991px){
-  .p-items_toc, .p-items_rightDummy {
-      display: none;
-  }
   .p-items_wrapper .p-items_article {
     max-width: 72rem;
     margin: 0 auto;
@@ -583,6 +577,7 @@
     grid-column: 1 / 4;
     -ms-grid-column: 1;
     -ms-grid-column-span: 4;
+    padding: 1.6rem;
   }
   .p-items_stickyMenu, .p-items_leftDummy {
     margin-left: 1.6rem;

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -21,7 +21,9 @@ class ArticlesController < ApplicationController
     @article = Article.create(article_params)
   end
 
-  def show; end
+  def show
+    @article = Article.find(params[:id])
+  end
 
   private
 

--- a/app/views/articles/show.html.haml
+++ b/app/views/articles/show.html.haml
@@ -16,52 +16,59 @@
             .it-Actions_commentCount 1
             .fa.fa-fw.fa-comment
           .SocialMediaShareButton.SocialMediaShareButton--twitter
-            %div
-              %svg.social-icon.social-icon--twitter{fill: "white", height: "32", viewbox: "0 0 64 64", width: "32"}
-                %g
-                  %circle{cx: "32", cy: "32", fill: "#00aced", r: "31"}
-                %g
-                  %path{d: "M48,22.1c-1.2,0.5-2.4,0.9-3.8,1c1.4-0.8,2.4-2.1,2.9-3.6c-1.3,0.8-2.7,1.3-4.2,1.6 C41.7,19.8,40,19,38.2,19c-3.6,0-6.6,2.9-6.6,6.6c0,0.5,0.1,1,0.2,1.5c-5.5-0.3-10.3-2.9-13.5-6.9c-0.6,1-0.9,2.1-0.9,3.3 c0,2.3,1.2,4.3,2.9,5.5c-1.1,0-2.1-0.3-3-0.8c0,0,0,0.1,0,0.1c0,3.2,2.3,5.8,5.3,6.4c-0.6,0.1-1.1,0.2-1.7,0.2c-0.4,0-0.8,0-1.2-0.1 c0.8,2.6,3.3,4.5,6.1,4.6c-2.2,1.8-5.1,2.8-8.2,2.8c-0.5,0-1.1,0-1.6-0.1c2.9,1.9,6.4,2.9,10.1,2.9c12.1,0,18.7-10,18.7-18.7 c0-0.3,0-0.6,0-0.8C46,24.5,47.1,23.4,48,22.1z"}
+            =link_to "", target:"_blank", onclick:"window.open('http://twitter.com/share?url=#{request.url}&hashtags=Quuta,球太','subwin','width=500,height=500'); return false;" do
+              %div
+                %svg.social-icon.social-icon--twitter{fill: "white", height: "32", viewbox: "0 0 64 64", width: "32"}
+                  %g
+                    %circle{cx: "32", cy: "32", fill: "#00aced", r: "31"}
+                  %g
+                    %path{d: "M48,22.1c-1.2,0.5-2.4,0.9-3.8,1c1.4-0.8,2.4-2.1,2.9-3.6c-1.3,0.8-2.7,1.3-4.2,1.6 C41.7,19.8,40,19,38.2,19c-3.6,0-6.6,2.9-6.6,6.6c0,0.5,0.1,1,0.2,1.5c-5.5-0.3-10.3-2.9-13.5-6.9c-0.6,1-0.9,2.1-0.9,3.3 c0,2.3,1.2,4.3,2.9,5.5c-1.1,0-2.1-0.3-3-0.8c0,0,0,0.1,0,0.1c0,3.2,2.3,5.8,5.3,6.4c-0.6,0.1-1.1,0.2-1.7,0.2c-0.4,0-0.8,0-1.2-0.1 c0.8,2.6,3.3,4.5,6.1,4.6c-2.2,1.8-5.1,2.8-8.2,2.8c-0.5,0-1.1,0-1.6-0.1c2.9,1.9,6.4,2.9,10.1,2.9c12.1,0,18.7-10,18.7-18.7 c0-0.3,0-0.6,0-0.8C46,24.5,47.1,23.4,48,22.1z"}
           .SocialMediaShareButton.SocialMediaShareButton--facebook{role: "button", style: "margin-top: 1.6rem;", tabindex: "0"}
-            %div{style: "width: 3.2rem; height: 3.2rem;"}
-              %svg.social-icon.social-icon--facebook{fill: "white", height: "32", viewbox: "0 0 64 64", width: "32"}
-                %g
-                  %circle{cx: "32", cy: "32", fill: "#3b5998", r: "31"}
-                %g
-                  %path{d: "M34.1,47V33.3h4.6l0.7-5.3h-5.3v-3.4c0-1.5,0.4-2.6,2.6-2.6l2.8,0v-4.8c-0.5-0.1-2.2-0.2-4.1-0.2 c-4.1,0-6.9,2.5-6.9,7V28H24v5.3h4.6V47H34.1z"}
+            =link_to "", onclick:"window.open('https://www.facebook.com/sharer/sharer.php?u=#{request.url}','subwin','width=500,height=500'); return false;" do
+              %div{style: "width: 3.2rem; height: 3.2rem;"}
+                %svg.social-icon.social-icon--facebook{fill: "white", height: "32", viewbox: "0 0 64 64", width: "32"}
+                  %g
+                    %circle{cx: "32", cy: "32", fill: "#3b5998", r: "31"}
+                  %g
+                    %path{d: "M34.1,47V33.3h4.6l0.7-5.3h-5.3v-3.4c0-1.5,0.4-2.6,2.6-2.6l2.8,0v-4.8c-0.5-0.1-2.2-0.2-4.1-0.2 c-4.1,0-6.9,2.5-6.9,7V28H24v5.3h4.6V47H34.1z"}
       .p-items_main
         .p-items_article
           .it-Header
             .u-flex-center-between.mb-3
               .it-Header_info
                 .it-Header_author
-                  %a{href:""}
-                    //ユーザーアイコンとリンク
-                    %img.it-Header_authorImage
-                  // ユーザーマイページのリンク
+                  =link_to "" do
+                    //ユーザーマイページのリンクを貼る
+                    - if @article.user.icon.present?
+                      =image_tag @article.user.icon.url, class:"it-Header_authorImage"
+                    - else 
+                      =image_tag "quutan.jpg", class:"it-Header_authorImage"
+                  //ユーザーマイページのリンクを貼る
                   %a.it-Header_authorName
                     ="@#{@article.user.nickname}"
                 .it-Header_time
                   =@article.updated_at.strftime("%Y年%m月%d日")
                   に更新
-                .it-Header_meta
-                  .it-Header_manipulate
-                    .it-Header_dropdown
-                      %a.it-Header_dropdownToggle{"aria-expanded":"false", "data-toggle":"dropdown", href:""}
-                        %span.fa.fa-ellipsis-h.fa-lg
-                      %ul.dropdown-menu.dropdown-menu-right
-                        %li.divider{role:"separator"}
-                        %li.dropdown__item
-                          %a{href:""}
-                            %span.fa.fa-fw.fa-thumbs-up
-                            いいねしたユーザー一覧
-                        %li.dropdown__item
-                          %a{href:""}
-                            %span.fa.fa-fw.fa-flag
-                            問題がある記事を報告する
-            %h1.it-Header_title タイトル
-            -# =@article.title
+                //記事のオプション（いいねしたユーザー一覧、通報機能）実装時に使用
+                -# .it-Header_meta
+                -#   .it-Header_manipulate
+                -#     .it-Header_dropdown
+                -#       %a.it-Header_dropdownToggle{"aria-expanded":"false", "data-toggle":"dropdown", href:""}
+                -#         %span.fa.fa-ellipsis-h.fa-lg
+                -#       %ul.dropdown-menu.dropdown-menu-right
+                -#         %li.divider{role:"separator"}
+                -#         %li.dropdown__item
+                -#           %a{href:""}
+                -#             %span.fa.fa-fw.fa-thumbs-up
+                -#             いいねしたユーザー一覧
+                -#         %li.dropdown__item
+                -#           %a{href:""}
+                -#             %span.fa.fa-fw.fa-flag
+                -#             問題がある記事を報告する
+            %h1.it-Header_title
+              =@article.title
             .it-Tags
+              //タグ実装時、活用
               %a.it-Tags_item{href:"/tags/chaosengineering"}
                 %span タグ
           %div{"data-mount-target":"mobileArticleActions"}
@@ -69,7 +76,7 @@
             #item-2245429ce96027e27949
               #content
                 #mdraw
-                  =@article.text
+                  = qiita_markdown(@article.text)
           %div{"data-mount-target": "articleFooterMenu"}
             .it-Footer
               .it-Footer_actions
@@ -84,50 +91,55 @@
                       %span いいね
                     %a.LikeButton__balloon{href: ""}  11
               .it-Footer_social
-                .SocialMediaShareButton.SocialMediaShareButton--twitter.it-Footer_shareButton.it-Footer_shareButton-twitter
-                  %div{style: "width: 3.2rem; height: 3.2rem;"}
-                    %svg.social-icon.social-icon--twitter{fill: "white", height: "32", viewbox: "0 0 64 64", width:"32"}
-                      %g
-                        %circle{cx: "32", cy: "32", fill: "#00aced", r: "31"}
-                      %g
-                        %path{d: "M48,22.1c-1.2,0.5-2.4,0.9-3.8,1c1.4-0.8,2.4-2.1,2.9-3.6c-1.3,0.8-2.7,1.3-4.2,1.6 C41.7,19.8,40,19,38.2,19c-3.6,0-6.6,2.9-6.6,6.6c0,0.5,0.1,1,0.2,1.5c-5.5-0.3-10.3-2.9-13.5-6.9c-0.6,1-0.9,2.1-0.9,3.3 c0,2.3,1.2,4.3,2.9,5.5c-1.1,0-2.1-0.3-3-0.8c0,0,0,0.1,0,0.1c0,3.2,2.3,5.8,5.3,6.4c-0.6,0.1-1.1,0.2-1.7,0.2c-0.4,0-0.8,0-1.2-0.1 c0.8,2.6,3.3,4.5,6.1,4.6c-2.2,1.8-5.1,2.8-8.2,2.8c-0.5,0-1.1,0-1.6-0.1c2.9,1.9,6.4,2.9,10.1,2.9c12.1,0,18.7-10,18.7-18.7 c0-0.3,0-0.6,0-0.8C46,24.5,47.1,23.4,48,22.1z"}
-                .SocialMediaShareButton.SocialMediaShareButton--facebookit-Footer_shareButton.it-Footer_shareButton-facebook
-                  %div{style: "width: 3.2rem; height: 3.2rem;"}
-                    %svg.social-icon.social-icon--facebook{fill: "white", height: "32", viewbox: "0 0 64 64", width: "32"}
-                      %g
-                        %circle{cx: "32", cy: "32", fill: "#3b5998", r: "31"}
-                      %g
-                        %path{d: "M34.1,47V33.3h4.6l0.7-5.3h-5.3v-3.4c0-1.5,0.4-2.6,2.6-2.6l2.8,0v-4.8c-0.5-0.1-2.2-0.2-4.1-0.2 c-4.1,0-6.9,2.5-6.9,7V28H24v5.3h4.6V47H34.1z"}
-              .__react_component_tooltip.place-top.type-dark
+                =link_to "", onclick:"window.open('http://twitter.com/share?url=#{request.url}&hashtags=Quuta,球太','subwin','width=500,height=500'); return false;" do
+                  .SocialMediaShareButton.SocialMediaShareButton--twitter.it-Footer_shareButton.it-Footer_shareButton-twitter
+                    %div{style: "width: 3.2rem; height: 3.2rem;"}
+                      %svg.social-icon.social-icon--twitter{fill: "white", height: "32", viewbox: "0 0 64 64", width:"32"}
+                        %g
+                          %circle{cx: "32", cy: "32", fill: "#00aced", r: "31"}
+                        %g
+                          %path{d: "M48,22.1c-1.2,0.5-2.4,0.9-3.8,1c1.4-0.8,2.4-2.1,2.9-3.6c-1.3,0.8-2.7,1.3-4.2,1.6 C41.7,19.8,40,19,38.2,19c-3.6,0-6.6,2.9-6.6,6.6c0,0.5,0.1,1,0.2,1.5c-5.5-0.3-10.3-2.9-13.5-6.9c-0.6,1-0.9,2.1-0.9,3.3 c0,2.3,1.2,4.3,2.9,5.5c-1.1,0-2.1-0.3-3-0.8c0,0,0,0.1,0,0.1c0,3.2,2.3,5.8,5.3,6.4c-0.6,0.1-1.1,0.2-1.7,0.2c-0.4,0-0.8,0-1.2-0.1 c0.8,2.6,3.3,4.5,6.1,4.6c-2.2,1.8-5.1,2.8-8.2,2.8c-0.5,0-1.1,0-1.6-0.1c2.9,1.9,6.4,2.9,10.1,2.9c12.1,0,18.7-10,18.7-18.7 c0-0.3,0-0.6,0-0.8C46,24.5,47.1,23.4,48,22.1z"}
+                =link_to "", onclick:"window.open('https://www.facebook.com/sharer/sharer.php?u=#{request.url}','subwin','width=500,height=500'); return false;" do
+                  .SocialMediaShareButton.SocialMediaShareButton--facebookit-Footer_shareButton.it-Footer_shareButton-facebook
+                    %div{style: "width: 3.2rem; height: 3.2rem;"}
+                      %svg.social-icon.social-icon--facebook{fill: "white", height: "32", viewbox: "0 0 64 64", width: "32"}
+                        %g
+                          %circle{cx: "32", cy: "32", fill: "#3b5998", r: "31"}
+                        %g
+                          %path{d: "M34.1,47V33.3h4.6l0.7-5.3h-5.3v-3.4c0-1.5,0.4-2.6,2.6-2.6l2.8,0v-4.8c-0.5-0.1-2.2-0.2-4.1-0.2 c-4.1,0-6.9,2.5-6.9,7V28H24v5.3h4.6V47H34.1z"}
           .ai-Container
             .ai-User
-              %a{href:""}
-                %img.ai-User_image{src:""}
-              .ai-User_body
-                .ai-User_header
-                  %a.ai-User_name{href: ""} MEI　SEI
-                  =link_to "@#{@article.user.nickname}", "",class:"ai-User_urlname"
-                .ai-User_description
-                  ユーザー説明
-                %a.ai-User_website{href: "http://d.hatena.ne.jp/mazinlabs"} ユーザーURL
-                .ai-User_footer
-                  %span.userFollowButton
-                    %button.btn.btn-default.btn-block.userFollowButton_inner.btn-xs
-                      %i.i.fa.fa-user-plus>
-                      フォロー
-                %script.js-react-on-rails-component
+              .ai-User_header
+                //マイページへのリンク
+                = link_to "" do
+                  -if @article.user.icon.present?
+                    =image_tag @article.user.icon.url, class:"ai-User_image"
+                  -else
+                    =image_tag "quutan.jpg", class:"ai-User_image"
+                .ai-User_name
+                  =link_to @article.user.profile.lastname + " " + @article.user.profile.firstname, ""
+                .ai-User_urlname
+                  =link_to "@#{@article.user.nickname}", ""
+              .ai-User_description
+                =@article.user.profile.description
+                // フォロー機能実装時使用
+                -# .ai-User_footer
+                -#   %span.userFollowButton
+                -#     %button.btn.btn-default.btn-block.userFollowButton_inner.btn-xs
+                -#       %i.i.fa.fa-user-plus>
+                -#       フォロー
       .p-items_options
-      .p-items_toc
-        .it-Toc
-          .it-Toc_nav
-            %ul
-              %li
-                %a{href: ""} 見出しごとのリンク
-                %ul
-                  %li
-                    %a{href: ""} 見出しごとのリンク
-              %li
-                %a{href: ""} 見出しごとのリンク
+      -# .p-items_toc
+      -#   .it-Toc
+      -#     .it-Toc_nav
+      -#       %ul
+      -#         %li
+      -#           %a{href: ""} 見出しごとのリンク
+      -#           %ul
+      -#             %li
+      -#               %a{href: ""} 見出しごとのリンク
+      -#         %li
+      -#           %a{href: ""} 見出しごとのリンク
   .p-items_container
     .p-items_leftDummy
     .p-items_main
@@ -146,7 +158,7 @@
         -#           リンクしてる記事
         -#         %span からリンク
         -#         %time.references_datetime.js-dateTimeView{:datetime => "2019-12-15T14:59:27+00:00"} 約14時間前
-        .p-items_aside.mt-5
+        -# .p-items_aside.mt-5
           -# コメント実装時、使用
           -# #comments.itemsShowComment_wrapper
           -#   #PublicCommentListContainer-react-component-3b26de0e-42d9-4a6c-94a5-69486093ba0a
@@ -249,6 +261,7 @@
 = render "shared/footer"
 
 
-:javascript
-  document.getElementById('content').innerHTML =
-    marked(document.getElementById("mdraw").innerHTML);
+%script{async: "", charset:"utf-8", src:"https://platform.twitter.com/widgets.js"}
+-# :javascript
+-#   document.getElementById('content').innerHTML =
+-#     marked(document.getElementById("mdraw").innerHTML);

--- a/app/views/profiles/edit.html.haml
+++ b/app/views/profiles/edit.html.haml
@@ -18,7 +18,7 @@
             ユーザー名が設定されていません
         -else
           =link_to "",{class:"setting_userName"} do
-            ="@#{current_user.nickname} アカウント"
+            ="@#{current_user.nickname}"
         %span.setting_titleSeparator /
         %span.setting_title プロフィール
       =form_for @profile,url:setting_profile_path, html:{id:"edit_user", class:"simple_form edit_user"} do |f|

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -18,11 +18,12 @@
             ユーザー名が設定されていません
         -else
           =link_to "",{class:"setting_userName"} do
-            ="@#{current_user.nickname} アカウント"
+            ="@#{current_user.nickname}"
         %span.setting_titleSeparator /
         %span.setting_title ユーザー設定
       =form_for @user,url:setting_account_path, html:{id:"edit_user", class:"simple_form edit_user"} do |f|
         .st-Form.icon
+          %label.st-Form_label アイコン
           = f.file_field :icon ,id:"lefile", style:"display:none"
           .icon_wrapper
             %input#photoCover.st-Form_text{placeholder:"（仮）10MBまでアップロードできます", type:"text"}


### PR DESCRIPTION
# What
記事詳細画面のビューで以下の点を修正しました。
・投稿者のアイコン、ユーザー名、姓名、自己紹介を表示
・SNSのシェアボタンのリンクを設定
主に以下のファイルを編集しました。
・articles/show.html.haml 
・articles/show.scss

# Why
記事詳細画面の機能を追加するため。
レビューの程よろしくお願いいたします。

<img width="987" alt="スクリーンショット 2019-12-28 15 30 47" src="https://user-images.githubusercontent.com/56331466/71539952-371a0f80-2987-11ea-8a29-6d206ad031d3.png">


<img width="912" alt="スクリーンショット 2019-12-28 15 30 36" src="https://user-images.githubusercontent.com/56331466/71539943-16ea5080-2987-11ea-8ef2-6410ca478709.png">
