### PR TITLE
【サーバーサイド、フロントサイド】トップページの新規登録画面の作成

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -21,3 +21,5 @@
 
 // profiles
 @import "profiles/edit";
+
+@import "homes";

--- a/app/assets/stylesheets/articles/new.scss
+++ b/app/assets/stylesheets/articles/new.scss
@@ -1,6 +1,6 @@
 .publicEditor {
   position: absolute;
-  top: 5.1rem;
+  top: 5.6rem;
   right: 0;
   bottom: 0;
   left: 0;

--- a/app/assets/stylesheets/homes.scss
+++ b/app/assets/stylesheets/homes.scss
@@ -1,3 +1,142 @@
-// Place all the styles related to the homes controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: http://sass-lang.com/
+.nl-Hero {
+  width: 100%;
+  padding: 3.2rem;
+  background-color: #55c500;
+  display: flex;
+  align-items: center;
+  .nl-Hero_inner {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    max-width: 110rem;
+    margin: 0 auto;
+    .nl-Hero_start {
+      .nl-Hero_title {
+        font-size: 4.8rem;
+        font-weight: 700;
+        font-feature-settings: "palt";
+        color: #fff;
+      }
+      .nl-Hero_lead {
+        width: 83%;
+        font-size: 1.6rem;
+        font-feature-settings: "pwid";
+        line-height: 2;
+        color: #fff;
+      }
+    }
+    .nl-Hero_end {
+      min-width: 30.5rem;
+      .nl-SocialSignupWrapper {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        width: 100%;
+        a {
+          text-decoration: none;
+        }
+        .nl-SocialSignup {
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          font-size: 1.4rem;
+          background-color: #fff;
+          border-radius: 0.4rem;
+          height: 4rem;
+          color: inherit;
+          transition: background-color .08s ease-in-out;
+          width: 30%;
+          .fab {
+            margin-right: 0.1rem;
+            font-size: 1.6rem;
+          }
+          .fa-twitter {
+            color: #55acee;;
+          }
+          .fa-google {
+            color: #c6594b;;
+          }
+          .fa-facebook {
+            color: #3b5998;
+          }
+        }
+      }
+      .nl-Hero_separator {
+        font-size: 1.3rem;
+        color: rgba(255,255,255,.6);
+        text-align: center;
+        margin: 0.8rem 0;
+      }
+      .nl-SignupForm {
+        display: flex;
+        flex-direction: column;
+        .nl-SignupForm_group {
+          display: flex;
+          align-items: center;
+          margin-left: -10rem;
+          .nl-SignupForm_label {
+            display: block;
+            font-size: 1.2rem;
+            color: #fff;
+            min-width: 10rem;
+            text-align: right;
+            padding-right: 1rem;
+            margin-bottom: 0;
+          }
+          .form-control {
+            width: 100%;
+            padding: 0.8rem;
+            box-shadow: inset 0 0.1rem 0.2rem #ccc;
+            border: 0;
+            font-size: 1.4rem;
+            height: 4rem;
+            border-radius: 0.4rem;
+          }
+        }
+        .nl-SignupForm_helpText {
+          display: block;
+          color: #fff;
+          font-size: 1rem;
+        }
+        .nl-SignupForm_recaptcha {
+          margin-bottom: 1.6rem;
+        }
+        .nl-SignupForm_buttonArea {
+          display: flex;
+          align-items: center;
+          .nl-SignupForm_button {
+            margin-right: 1.6rem;
+            .btn {
+              display: inline-block;
+              text-align: center;
+              width: 12rem;
+              height: 4rem;
+              background-color: transparent;
+              border: 0.2rem solid #fff;
+              border-radius: 0.4rem;
+              padding: 0.8rem;
+              font-size: 1.4rem;
+              cursor: pointer;
+              color: #fff;
+              transition: background-color .08s ease-in-out;
+            }
+          }
+        }
+        @media screen and (max-width: 40rem) {
+          .nl-SignupForm_group{
+            display:block;
+            margin-left: 0;
+            .nl-SignupForm_label {
+              text-align: left;
+            }
+          }
+        }
+      }
+    }
+  }
+  @media screen and (max-width: 40rem) {
+    .nl-Hero_inner{
+    display:block;
+    }
+  }
+}

--- a/app/controllers/homes_controller.rb
+++ b/app/controllers/homes_controller.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
 class HomesController < ApplicationController
-  def index; end
+  def index
+    @user = User.new
+  end
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -4,6 +4,16 @@ class Users::RegistrationsController < Devise::RegistrationsController
   prepend_before_action :check_captcha, only: [:create]
   prepend_before_action :customize_sign_up_params, only: [:create]
 
+  def create
+    @user = User.new(user_params)
+    if @user.save!
+      sign_in @user unless user_signed_in?
+      redirect_to root_path
+    else
+      redirect_to root_path
+    end
+  end
+
   private
 
   def customize_sign_up_params
@@ -16,5 +26,9 @@ class Users::RegistrationsController < Devise::RegistrationsController
     unless verify_recaptcha(model: resource)
       respond_with_navigational(resource) { render :new }
     end
+  end
+
+  def user_params
+    params.require(:user).permit(:nickname, :email, :password)
   end
 end

--- a/app/views/homes/index.html.haml
+++ b/app/views/homes/index.html.haml
@@ -1,8 +1,44 @@
 = render "shared/header"
-      
+
 = link_to "logout","/signout",{method: :delete}
 - if user_signed_in?
   = current_user.nickname
   = current_user.email
-test
+- else
+  .nl-Hero
+    .nl-Hero_inner
+      .nl-Hero_start
+        %h1.mb-4.nl-Hero_title How developers code is here.
+        %p.nl-Hero_lead 
+          Qiitaは、エンジニアリングに関する知識を記録・共有するためのサービスです。コードを書いていて気づいたことや、自分がハマったあの仕様について、他のエンジニアと知見を共有しましょう ;)
+      .nl-Hero_end
+        .nl-SocialSignupWrapper
+          =link_to user_twitter_omniauth_authorize_path ,class:"nl-SocialSignup nl-SocialSignup-twitter" do
+            %i.fab.fa-twitter.fa-fw
+            Twitter
+          =link_to user_google_oauth2_omniauth_authorize_path ,class:"nl-SocialSignup nl-SocialSignup-google" do
+            %i.fab.fa-google.fa-fw
+            Google
+          =link_to user_facebook_omniauth_authorize_path ,class:"nl-SocialSignup nl-SocialSignup-facebook" do
+            %i.fab.fa-facebook.fa-fw
+            Facebook
+        .nl-Hero_separator OR
+        .nl-SignupForm
+          =form_for @user, url: signup_path, method: :post do |f|
+            .mb-4.nl-SignupForm_group
+              %label.nl-SignupForm_label{for: "url_name"} ユーザ名
+              = f.text_field :nickname, class:"form-control", id:"url_name", placeholder:"ユーザ名", required:"required"
+            .mb-4.nl-SignupForm_group
+              %label.nl-SignupForm_label{for: "email"} メールアドレス
+              = f.email_field :email, class:"form-control", id:"email", placeholder:"メールアドレス", required:"required"
+            .mb-3.nl-SignupForm_group
+              %label.nl-SignupForm_label{for: "password"} パスワード
+              = f.password_field :password, class:"form-control", id:"password", placeholder:"********", required:"required"
+            %span.mb-4.nl-SignupForm_helpText パスワードは8文字以上32文字以内で、半角英字・数字・記号が使えます。
+            .nl-SignupForm_recaptcha
+              = recaptcha_tags
+            .nl-SignupForm_buttonArea
+              .nl-SignupForm_button
+                = f.submit class:"btn btn-primary btn-block btn-lg", "data-disable-with": "送信中……", value:"登録する"
+
 = render "shared/footer"


### PR DESCRIPTION
# what
トップページで新規登録できるようにしました。

主に変更したファイル
・users/registrations_controller
・views/homes/index.html.haml
・stylesheets/homes.scss

# why
トップページからでも新規登録できるようにするため。

<img width="1440" alt="スクリーンショット 2020-01-07 13 25 17" src="https://user-images.githubusercontent.com/56573437/71869033-f921a600-3153-11ea-8b95-dc541c9c1172.png">
